### PR TITLE
Reduce heap allocations to zero

### DIFF
--- a/Benchmark/FastParserBenchmark.cs
+++ b/Benchmark/FastParserBenchmark.cs
@@ -10,6 +10,7 @@ using csFastFloat.Structures;
 using System;
 using System.Globalization;
 
+[MemoryDiagnoser]
 [SimpleJob(RuntimeMoniker.NetCoreApp50)]
 [Config(typeof(Config))]
 public class MyBencmark

--- a/csFastFloat/FastDoubleParser.cs
+++ b/csFastFloat/FastDoubleParser.cs
@@ -17,7 +17,7 @@ namespace csFastFloat
 
 
 
-  public sealed class FastDoubleParser
+  public static class FastDoubleParser
   {
 
     public  static double exact_power_of_ten(long power) => Constants.powers_of_ten_double[power];

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 
 namespace csFastFloat
 {
-  public sealed class FastFloatParser
+  public static class FastFloatParser
   {
 
     public static float exact_power_of_ten(long power) => Constants.powers_of_ten_float[power];
@@ -266,7 +266,7 @@ namespace csFastFloat
       }
       const int max_shift = 60;
       const uint num_powers = 19;
-      byte[] powers = {
+      ReadOnlySpan<byte> powers = new byte[] {
                               0,  3,  6,  9,  13, 16, 19, 23, 26, 29, //
                               33, 36, 39, 43, 46, 49, 53, 56, 59,     //
                           };
@@ -274,7 +274,7 @@ namespace csFastFloat
       while (d.decimal_point > 0)
       {
         uint n = (uint)(d.decimal_point);
-        int shift = (n < num_powers) ? powers[n] : max_shift;
+        int shift = (n < num_powers) ? powers[(int)n] : max_shift;
 
         d.decimal_right_shift(shift);
         if (d.decimal_point < -Constants.decimal_point_range)
@@ -303,7 +303,7 @@ namespace csFastFloat
         else
         {
           uint n = (uint)(-d.decimal_point);
-          shift = (n < num_powers) ? powers[n] : max_shift;
+          shift = (n < num_powers) ? powers[(int)n] : max_shift;
         }
 
         d.decimal_left_shift(shift);

--- a/csFastFloat/Structures/AdjustedMantissa.cs
+++ b/csFastFloat/Structures/AdjustedMantissa.cs
@@ -2,7 +2,7 @@
 
 namespace csFastFloat.Structures
 {
-  public sealed class  AdjustedMantissa
+  public struct AdjustedMantissa
   {
     internal ulong mantissa;
     internal int power2; // a negative value indicates an invalid result

--- a/csFastFloat/Structures/ParsedNumberString.cs
+++ b/csFastFloat/Structures/ParsedNumberString.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace csFastFloat.Structures
 {
-  public unsafe sealed class ParsedNumberString
+  public unsafe struct ParsedNumberString
   {
     internal long exponent;
     internal ulong mantissa;

--- a/csFastFloat/Utils/Utils.cs
+++ b/csFastFloat/Utils/Utils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
 [assembly: InternalsVisibleTo("TestcsFastFloat")]
@@ -97,22 +98,26 @@ namespace csFastFloat
       return new value128(h: p11 + (middle >> 32) + (p01 >> 32), l: (middle << 32) | (uint)p00);
     }
 
+
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool is_space(byte c)
     {
-      bool[] table = new bool[] {
-      false, false, false, false, false, false, false, false, false, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
-      false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
-      return table[c];
+        ReadOnlySpan<byte> is_space_table = new byte[] { // a hack to store this array in the metadata (doesn't allocate)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+        byte b = Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(is_space_table), (IntPtr)c); // avoid bound checks
+        return Unsafe.As<byte, bool>(ref b);
     }
 
     [ExcludeFromCodeCoverage]


### PR DESCRIPTION
@lemire @CarlVerret Amazing work!! (both the algorithm and the C# port) I've made a couple of changes to reduce heap allocations (and made it zero-alloc basically) here are the benchmark results:

Was (see allocations in the last column):
```
|                             Method |      Mean |     Error |    StdDev |       Min | Ratio |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|----------------------------------- |----------:|----------:|----------:|----------:|------:|----------:|------:|------:|-----------:|
|               FastFloat.PaseDouble |  9.642 ms | 0.1912 ms | 0.2276 ms |  9.390 ms |  0.37 | 6179.6875 |     - |     - | 38803136 B |
|     'FastFloat.PaseDouble w/o <T>' |  9.738 ms | 0.1862 ms | 0.1742 ms |  9.508 ms |  0.38 | 6171.8750 |     - |     - | 38803136 B |
| 'FastFloat.PaseDouble - constants' |  9.851 ms | 0.1934 ms | 0.2070 ms |  9.487 ms |  0.38 | 6171.8750 |     - |     - | 38803136 B |
|                         'PNS only' |  2.708 ms | 0.0128 ms | 0.0107 ms |  2.692 ms |  0.10 |  707.0313 |     - |     - |  4445040 B |
|                     Double.Parse() | 25.843 ms | 0.0570 ms | 0.0476 ms | 25.774 ms |  1.00 |         - |     - |     - |          - |
```
This PR:
```
|                             Method |      Mean |     Error |    StdDev |       Min | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |----------:|----------:|----------:|----------:|------:|------:|------:|------:|----------:|
|               FastFloat.PaseDouble |  4.875 ms | 0.0142 ms | 0.0126 ms |  4.854 ms |  0.19 |     - |     - |     - |         - |
|     'FastFloat.PaseDouble w/o <T>' |  4.871 ms | 0.0206 ms | 0.0172 ms |  4.854 ms |  0.19 |     - |     - |     - |         - |
| 'FastFloat.PaseDouble - constants' |  4.930 ms | 0.0422 ms | 0.0395 ms |  4.892 ms |  0.19 |     - |     - |     - |         - |
|                         'PNS only' |  2.610 ms | 0.0054 ms | 0.0042 ms |  2.603 ms |  0.10 |     - |     - |     - |         - |
|                     Double.Parse() | 25.714 ms | 0.2072 ms | 0.1938 ms | 25.498 ms |  1.00 |     - |     - |     - |         - |
```

Overall the algorithm is insanely fast! (5x faster???) I'll try to run all the tests we have in the dotnet/runtime for floating points this weekend