### PR TITLE
Remove agressiveinlining where unnecessary

### DIFF
--- a/csFastFloat/FastDoubleParser.cs
+++ b/csFastFloat/FastDoubleParser.cs
@@ -232,12 +232,15 @@ namespace csFastFloat
     }
 
 
-   
 
 
+    static readonly byte[] powers = {
+        0,  3,  6,  9,  13, 16, 19, 23, 26, 29, //
+        33, 36, 39, 43, 46, 49, 53, 56, 59,     //
+    };
 
 
-    internal static AdjustedMantissa ComputeFloat(DecimalInfo d)
+        internal static AdjustedMantissa ComputeFloat(DecimalInfo d)
     {
       AdjustedMantissa answer = new AdjustedMantissa();
       if (d.num_digits == 0)
@@ -274,10 +277,7 @@ namespace csFastFloat
       }
       const int max_shift = 60;
       const uint num_powers = 19;
-      byte[] powers = {
-                              0,  3,  6,  9,  13, 16, 19, 23, 26, 29, //
-                              33, 36, 39, 43, 46, 49, 53, 56, 59,     //
-                          };
+
       int exp2 = 0;
       while (d.decimal_point > 0)
       {
@@ -378,11 +378,8 @@ namespace csFastFloat
       return ComputeFloat(d);
     }
 
-    
 
 
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     unsafe static internal double HandleInvalidInput(char* first, char* last)
     {
       if (last - first >= 3)

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -374,7 +374,6 @@ namespace csFastFloat
 
 
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     unsafe static internal float HandleInvalidInput(char* first, char* last)
     {
       if (last - first >= 3)
@@ -410,7 +409,6 @@ namespace csFastFloat
 
 
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     unsafe static internal ParsedNumberString ParseNumberString(char* p, char* pend, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
       ParsedNumberString answer = new ParsedNumberString();

--- a/csFastFloat/Structures/DecimalInfo.cs
+++ b/csFastFloat/Structures/DecimalInfo.cs
@@ -288,7 +288,6 @@ namespace csFastFloat.Structures
       trim();
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     unsafe internal static DecimalInfo parse_decimal(char* p, char* pend, char decimal_separator)
     {
       DecimalInfo answer = new DecimalInfo() { negative = (*p == '-'), digits = new byte[Constants.max_digits] };

--- a/csFastFloat/Structures/ParsedNumberString.cs
+++ b/csFastFloat/Structures/ParsedNumberString.cs
@@ -12,7 +12,6 @@ namespace csFastFloat.Structures
     internal bool too_many_digits;
 
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     unsafe static internal ParsedNumberString ParseNumberString(char* p, char* pend, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
       ParsedNumberString answer = new ParsedNumberString();

--- a/csFastFloat/Utils/Utils.cs
+++ b/csFastFloat/Utils/Utils.cs
@@ -25,7 +25,7 @@ namespace csFastFloat
     // Next function can be micro-optimized, but compilers are entirely
     // able to optimize it well.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static bool is_integer(char c) => c >= '0' && c <= '9';
+    internal static bool is_integer(char c) => (char)(c - '0') <= '9' - '0';
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static value128 compute_product_approximation(int bitPrecision, long q, ulong w)
@@ -69,7 +69,6 @@ namespace csFastFloat
 
 #else
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal unsafe static value128 FullMultiplication(ulong value1, ulong value2)
     {
       ulong lo;


### PR DESCRIPTION
Remove `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for large methods and for rarely-executed such as "HandleInvalidInput"

Unfortunately, JIT has some limits of locals (temp variables) it's able to track, once the amount reaches the limit we start to notice very slow spills (stack).

This PR makes benchmarks 5% faster.