### PR TITLE
Use an intermediary cast in is_space

### DIFF
--- a/csFastFloat/Utils/Utils.cs
+++ b/csFastFloat/Utils/Utils.cs
@@ -117,7 +117,7 @@ namespace csFastFloat
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
-        // Avoid bound checking. The seemingly pointless cast to uint removes a mov instruction. 
+        // Avoid bound checking. The seemingly pointless cast to uint removes the sign-extending movsxd instruction. 
         return Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(table), (IntPtr)(uint)c);
     }
 

--- a/csFastFloat/Utils/Utils.cs
+++ b/csFastFloat/Utils/Utils.cs
@@ -104,6 +104,7 @@ namespace csFastFloat
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool is_space(byte c)
     {
+        // ROS for one byte types can be read directly from metadata avoiding the array allocation.
         ReadOnlySpan<bool> table = new bool[] {
             false, false, false, false, false, false, false, false, false, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
@@ -116,7 +117,7 @@ namespace csFastFloat
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
-
+        // Avoid bound checking. The seemingly pointless cast to uint removes a mov instruction. 
         return Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(table), (IntPtr)(uint)c);
     }
 

--- a/csFastFloat/Utils/Utils.cs
+++ b/csFastFloat/Utils/Utils.cs
@@ -104,21 +104,20 @@ namespace csFastFloat
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool is_space(byte c)
     {
-        ReadOnlySpan<byte> is_space_table = new byte[] { // a hack to store this array in the metadata (doesn't allocate)
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        ReadOnlySpan<bool> table = new bool[] {
+            false, false, false, false, false, false, false, false, false, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
 
-        byte b = Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(is_space_table), (IntPtr)c); // avoid bound checks
-        return Unsafe.As<byte, bool>(ref b);
+        return Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(table), (IntPtr)(uint)c);
     }
 
     [ExcludeFromCodeCoverage]


### PR DESCRIPTION
The intermediary cast removes one mov to do sign expansion. If this project targeted C#9 we could instead use nint directly.

In addition, I switched the table back to bool. The ROS optimization kicks in for any one byte type. This produces less IL, which improves the chance for this method to get inlined in larger methods.

Closes #51 
