### PR TITLE
Utf8Literals instead hand-crafted byte-sequences

### DIFF
--- a/csFastFloat/Constants/Utf8Literals.cs
+++ b/csFastFloat/Constants/Utf8Literals.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace csFastFloat
+{
+  internal partial class Utf8Literals
+  {
+    [StringLiteral.Utf8("infinity")]
+    public static partial ReadOnlySpan<byte> infinity_string();
+    
+    [StringLiteral.Utf8("inf")]
+    public static partial ReadOnlySpan<byte> inf_string();
+    
+    [StringLiteral.Utf8("+inf")]
+    public static partial ReadOnlySpan<byte> pinf_string();
+    
+    [StringLiteral.Utf8("-inf")]
+    public static partial ReadOnlySpan<byte> minf_string();
+    
+    [StringLiteral.Utf8("nan")]
+    public static partial ReadOnlySpan<byte> nan_string();
+    
+    [StringLiteral.Utf8("+nan")]
+    public static partial ReadOnlySpan<byte> pnan_string();
+    
+    [StringLiteral.Utf8("-nan")]
+    public static partial ReadOnlySpan<byte> mnan_string();
+  }
+}

--- a/csFastFloat/FastDoubleParser.cs
+++ b/csFastFloat/FastDoubleParser.cs
@@ -452,47 +452,29 @@ namespace csFastFloat
       return 0d;
     }
 
-
     unsafe static internal double HandleInvalidInput(byte* first, byte* last)
     {
-      // C# does not (yet) allow literal ASCII strings (it uses UTF-16), so
-      // we need to use byte arrays.
-      // "infinity"  string in ASCII, e.g., 105 = i
-      ReadOnlySpan<byte> infinity_string = new byte[]{105, 110, 102, 105, 110, 105, 116, 121};
-      // "inf" string in ASCII
-      ReadOnlySpan<byte> inf_string = new byte[]{105, 110, 102};
-      // "+inf" string in ASCII
-      ReadOnlySpan<byte> pinf_string = new byte[]{43, 105, 110, 102};
-      // "-inf" string in ASCII
-      ReadOnlySpan<byte> minf_string = new byte[]{5, 105, 110, 102};
-      // "nan" string in ASCII
-      ReadOnlySpan<byte> nan_string = new byte[]{110, 97, 110};
-      // "-nan" string in ASCII
-      ReadOnlySpan<byte> mnan_string = new byte[]{45, 110, 97, 110};
-      // "+nan" string in ASCII
-      ReadOnlySpan<byte> pnan_string = new byte[]{43, 110, 97, 110};
-
       if (last - first >= 3)
       {
-        if (Utils.strncasecmp(first, nan_string, 3))
+        if (Utils.strncasecmp(first, Utf8Literals.nan_string(), 3))
         {
           return DoubleBinaryConstants.NaN;
         }
-        if (Utils.strncasecmp(first, inf_string, 3))
+        if (Utils.strncasecmp(first, Utf8Literals.inf_string(), 3))
         {
-          if ((last - first >= 8) && Utils.strncasecmp(first, infinity_string, 8))
+          if ((last - first >= 8) && Utils.strncasecmp(first, Utf8Literals.infinity_string(), 8))
             return DoubleBinaryConstants.PositiveInfinity;
           return DoubleBinaryConstants.PositiveInfinity;
         }
         if (last - first >= 4)
         {
-          if (Utils.strncasecmp(first, pnan_string, 4) || Utils.strncasecmp(first, mnan_string, 4))
+          if (Utils.strncasecmp(first, Utf8Literals.pnan_string(), 4) || Utils.strncasecmp(first, Utf8Literals.mnan_string(), 4))
           {
             return DoubleBinaryConstants.NaN;
           }
-          if (Utils.strncasecmp(first, pinf_string, 4) ||
-              Utils.strncasecmp(first, minf_string, 4) ||
-              ((last - first >= 8) && Utils.strncasecmp(first + 1, infinity_string, 8)))
+          if (Utils.strncasecmp(first, Utf8Literals.pinf_string(), 4) ||
+              Utils.strncasecmp(first, Utf8Literals.minf_string(), 4) ||
+              ((last - first >= 8) && Utils.strncasecmp(first + 1, Utf8Literals.infinity_string(), 8)))
           {
             return (first[0] == '-') ? DoubleBinaryConstants.NegativeInfinity : DoubleBinaryConstants.PositiveInfinity;
           }

--- a/csFastFloat/FastDoubleParser.cs
+++ b/csFastFloat/FastDoubleParser.cs
@@ -115,7 +115,7 @@ namespace csFastFloat
       return ToFloat(pns.negative, am);
     }
    
-    unsafe static internal Double ParseNumber (byte* first, byte* last, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
+    unsafe static internal double ParseNumber (byte* first, byte* last, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
     {
       while ((first != last) && Utils.is_space(*first))
       {
@@ -153,9 +153,9 @@ namespace csFastFloat
 
     public static unsafe double ParseDouble(ReadOnlySpan<byte> s, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
     {
-      fixed(byte* pStart = s)
+      fixed (byte* pStart = s)
       {
-        return ParseNumber(pStart, pStart + s.Length, expectedFormat, decimal_separator);
+        return ParseNumber(pStart, pStart + (uint)s.Length, expectedFormat, decimal_separator);
       }
     }
 

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -151,9 +151,9 @@ namespace csFastFloat
     }
     public static unsafe float ParseFloat(ReadOnlySpan<byte> s, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
     {
-      fixed(byte* pStart = s)
+      fixed (byte* pStart = s)
       {
-        return ParseNumber(pStart, pStart + s.Length, expectedFormat, decimal_separator);
+        return ParseNumber(pStart, pStart + (uint)s.Length, expectedFormat, decimal_separator);
       }
     }
 

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -659,7 +659,7 @@ namespace csFastFloat
         {
           return answer;
         }
-        if (!Utils.is_integer(*p, out uint digit) && (*p != decimal_separator)) // culture info ?
+        if (!Utils.is_integer(*p, out uint _) && (*p != decimal_separator)) // culture info ?
         { // a  sign must be followed by an integer or the dot
           return answer;
         }
@@ -718,7 +718,7 @@ namespace csFastFloat
         {
           ++p;
         }
-        if ((p == pend) || !Utils.is_integer(*p, out uint digit))
+        if ((p == pend) || !Utils.is_integer(*p, out uint _))
         {
           if (expectedFormat != chars_format.is_fixed)
           {

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -461,44 +461,27 @@ namespace csFastFloat
 
     unsafe static internal float HandleInvalidInput(byte* first, byte* last)
     {
-      // C# does not (yet) allow literal ASCII strings (it uses UTF-16), so
-      // we need to use byte arrays.
-      // "infinity"  string in ASCII, e.g., 105 = i
-      ReadOnlySpan<byte> infinity_string = new byte[]{105, 110, 102, 105, 110, 105, 116, 121};
-      // "inf" string in ASCII
-      ReadOnlySpan<byte> inf_string = new byte[]{105, 110, 102};
-      // "+inf" string in ASCII
-      ReadOnlySpan<byte> pinf_string = new byte[]{43, 105, 110, 102};
-      // "-inf" string in ASCII
-      ReadOnlySpan<byte> minf_string = new byte[]{5, 105, 110, 102};
-      // "nan" string in ASCII
-      ReadOnlySpan<byte> nan_string = new byte[]{110, 97, 110};
-      // "-nan" string in ASCII
-      ReadOnlySpan<byte> mnan_string = new byte[]{45, 110, 97, 110};
-      // "+nan" string in ASCII
-      ReadOnlySpan<byte> pnan_string = new byte[]{43, 110, 97, 110};
-
       if (last - first >= 3)
       {
-        if (Utils.strncasecmp(first, nan_string, 3))
+        if (Utils.strncasecmp(first, Utf8Literals.nan_string(), 3))
         {
           return FloatBinaryConstants.NaN;
         }
-        if (Utils.strncasecmp(first, inf_string, 3))
+        if (Utils.strncasecmp(first, Utf8Literals.inf_string(), 3))
         {
-          if ((last - first >= 8) && Utils.strncasecmp(first, infinity_string, 8))
+          if ((last - first >= 8) && Utils.strncasecmp(first, Utf8Literals.infinity_string(), 8))
             return FloatBinaryConstants.PositiveInfinity;
           return FloatBinaryConstants.PositiveInfinity;
         }
         if (last - first >= 4)
         {
-          if (Utils.strncasecmp(first, pnan_string, 4) || Utils.strncasecmp(first, mnan_string, 4))
+          if (Utils.strncasecmp(first, Utf8Literals.pnan_string(), 4) || Utils.strncasecmp(first, Utf8Literals.mnan_string(), 4))
           {
             return FloatBinaryConstants.NaN;
           }
-          if (Utils.strncasecmp(first, pinf_string, 4) ||
-              Utils.strncasecmp(first, minf_string, 4) ||
-              ((last - first >= 8) && Utils.strncasecmp(first + 1, infinity_string, 8)))
+          if (Utils.strncasecmp(first, Utf8Literals.pinf_string(), 4) ||
+              Utils.strncasecmp(first, Utf8Literals.minf_string(), 4) ||
+              ((last - first >= 8) && Utils.strncasecmp(first + 1, Utf8Literals.infinity_string(), 8)))
           {
             return (first[0] == '-') ? FloatBinaryConstants.NegativeInfinity : FloatBinaryConstants.PositiveInfinity;
           }

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -508,7 +508,7 @@ namespace csFastFloat
         {
           return answer;
         }
-        if (!Utils.is_integer(*p, out uint _) && (*p != decimal_separator)) // culture info ?
+        if (!Utils.is_integer(*p, out _) && (*p != decimal_separator)) // culture info ?
         { // a  sign must be followed by an integer or the dot
           return answer;
         }
@@ -559,7 +559,7 @@ namespace csFastFloat
         {
           ++p;
         }
-        if ((p == pend) || !Utils.is_integer(*p, out uint _))
+        if ((p == pend) || !Utils.is_integer(*p, out _))
         {
           if (expectedFormat != chars_format.is_fixed)
           {
@@ -659,7 +659,7 @@ namespace csFastFloat
         {
           return answer;
         }
-        if (!Utils.is_integer(*p, out uint _) && (*p != decimal_separator)) // culture info ?
+        if (!Utils.is_integer(*p, out _) && (*p != decimal_separator)) // culture info ?
         { // a  sign must be followed by an integer or the dot
           return answer;
         }
@@ -718,7 +718,7 @@ namespace csFastFloat
         {
           ++p;
         }
-        if ((p == pend) || !Utils.is_integer(*p, out uint _))
+        if ((p == pend) || !Utils.is_integer(*p, out _))
         {
           if (expectedFormat != chars_format.is_fixed)
           {

--- a/csFastFloat/Structures/ParsedNumberString.cs
+++ b/csFastFloat/Structures/ParsedNumberString.cs
@@ -177,7 +177,7 @@ namespace csFastFloat.Structures
         {
           return answer;
         }
-        if (!Utils.is_integer(*p, out uint digit) && (*p != decimal_separator))
+        if (!Utils.is_integer(*p, out uint _) && (*p != decimal_separator))
         { // a  sign must be followed by an integer or the dot
           return answer;
         }
@@ -236,7 +236,7 @@ namespace csFastFloat.Structures
         {
           ++p;
         }
-        if ((p == pend) || !Utils.is_integer(*p, out uint digit))
+        if ((p == pend) || !Utils.is_integer(*p, out uint _))
         {
           if (expectedFormat != chars_format.is_fixed)
           {

--- a/csFastFloat/Structures/ParsedNumberString.cs
+++ b/csFastFloat/Structures/ParsedNumberString.cs
@@ -26,7 +26,7 @@ namespace csFastFloat.Structures
         {
           return answer;
         }
-        if (!Utils.is_integer(*p, out uint _) && (*p != decimal_separator)) // culture info ?
+        if (!Utils.is_integer(*p, out _) && (*p != decimal_separator)) // culture info ?
         { // a  sign must be followed by an integer or the dot
           return answer;
         }
@@ -77,7 +77,7 @@ namespace csFastFloat.Structures
         {
           ++p;
         }
-        if ((p == pend) || !Utils.is_integer(*p, out uint _))
+        if ((p == pend) || !Utils.is_integer(*p, out _))
         {
           if (expectedFormat != chars_format.is_fixed)
           {
@@ -177,7 +177,7 @@ namespace csFastFloat.Structures
         {
           return answer;
         }
-        if (!Utils.is_integer(*p, out uint _) && (*p != decimal_separator))
+        if (!Utils.is_integer(*p, out _) && (*p != decimal_separator))
         { // a  sign must be followed by an integer or the dot
           return answer;
         }
@@ -236,7 +236,7 @@ namespace csFastFloat.Structures
         {
           ++p;
         }
-        if ((p == pend) || !Utils.is_integer(*p, out uint _))
+        if ((p == pend) || !Utils.is_integer(*p, out _))
         {
           if (expectedFormat != chars_format.is_fixed)
           {

--- a/csFastFloat/csFastFloat.csproj
+++ b/csFastFloat/csFastFloat.csproj
@@ -30,4 +30,8 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StringLiteralGenerator" Version="1.0.1" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Additional:

* remove `movsxd`, as they're not needed
* used C# language to denote if an argument should be ignored