### PR TITLE
Fixes the unicode "is_space".

### DIFF
--- a/csFastFloat/FastDoubleParser.cs
+++ b/csFastFloat/FastDoubleParser.cs
@@ -81,7 +81,7 @@ namespace csFastFloat
  
     unsafe static internal double ParseNumber(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
-      while ((first != last) && Utils.is_space((byte)(*first)))
+      while ((first != last) && Utils.is_ascii_space(*first))
       {
         first++;
       }

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -79,7 +79,7 @@ namespace csFastFloat
 
     unsafe static internal float ParseNumber(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
-      while ((first != last) && Utils.is_space((byte)(*first)))
+      while ((first != last) && Utils.is_ascii_space(*first))
       {
         first++;
       }

--- a/csFastFloat/Utils/Utils.cs
+++ b/csFastFloat/Utils/Utils.cs
@@ -149,6 +149,16 @@ namespace csFastFloat
 
 #endif
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool is_ascii_space(char c)
+    {
+        // ROS for one byte types can be read directly from metadata avoiding the array allocation.
+        ReadOnlySpan<bool> table = new bool[] {
+            false, false, false, false, false, false, false, false, false, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, true};
+        // Avoid bound checking.
+        return (c >32) ? false : Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(table), (nint)c);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool is_space(byte c)


### PR DESCRIPTION
Current "is_space" function may misidentify some unicode characters as white space. This is a fix.