### PR TITLE
Reporting the number of characters consumed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AMD EPYC 7262, 1 CPU, 16 logical and 8 physical cores
   [Host]        : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
   .NET Core 5.0 : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
 
-Job=.NET Core 5.0  Runtime=.NET Core 5.0  
+Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
 |                     Method |        FileName |      Mean |     Error |    StdDev |       Min | Ratio | MFloat/s |     MB/s |
 |--------------------------- |---------------- |----------:|----------:|----------:|----------:|------:|---------:|---------:|
@@ -32,12 +32,12 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
 ```
 
-In this repo [FastFloatTestBench](https://github.com/CarlVerret/FastFloatTestBench) we demonstrate a concrete performance gain obtained with FastFloat.ParseDouble() with the [CSVHelper](https://github.com/JoshClose/CsvHelper) library.  This is one of the fastest CSV parser available.  
+In this repo [FastFloatTestBench](https://github.com/CarlVerret/FastFloatTestBench) we demonstrate a concrete performance gain obtained with FastFloat.ParseDouble() with the [CSVHelper](https://github.com/JoshClose/CsvHelper) library.  This is one of the fastest CSV parser available.
 
 Single and multiple columns files have been tested. :
-- Canada.txt and mesh.txt are the same from previous benchmark.  
-- Syntethic.csv is composed of 150 000 random floats. 
-- World cities population data (100k/300k) are real data obtained from [OpenDataSoft](https://public.opendatasoft.com/explore/dataset/worldcitiespop).  
+- Canada.txt and mesh.txt are the same from previous benchmark.
+- Syntethic.csv is composed of 150 000 random floats.
+- World cities population data (100k/300k) are real data obtained from [OpenDataSoft](https://public.opendatasoft.com/explore/dataset/worldcitiespop).
 
 Benchmark is run on same environment.
 
@@ -49,7 +49,7 @@ AMD EPYC 7262, 1 CPU, 16 logical and 8 physical cores
   [Host]        : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
   .NET Core 5.0 : .NET Core 5.0.2 (CoreCLR 5.0.220.61120, CoreFX 5.0.220.61120), X64 RyuJIT
 
-Job=.NET Core 5.0  Runtime=.NET Core 5.0  
+Job=.NET Core 5.0  Runtime=.NET Core 5.0
 |                                Method |               fileName | fileSize | nbFloat |      Mean |    Error |   StdDev |       Min | Ratio | MFloat/s |
 |-------------------------------------- |----------------------- |--------- |-------- |----------:|---------:|---------:|----------:|------:|---------:|
 |          'Double.Parse() - singlecol' |    TestData/canada.txt |     2088 |  111126 |  84.46 ms | 0.271 ms | 0.226 ms |  84.16 ms |  1.00 |     1.32 |
@@ -78,7 +78,7 @@ Job=.NET Core 5.0  Runtime=.NET Core 5.0
 
 # Requirements
 
-.NET Core 3.1 or better. Under .NET 5 framework, the library takes advantage of the new Math.BigMul() function.  
+.NET Core 3.1 or better. Under .NET 5 framework, the library takes advantage of the new Math.BigMul() function.
 
 # Usage
 
@@ -102,11 +102,17 @@ foreach (string l in lines)
 
 Input strings are expected to be valid UTF-16.
 
-For UTF-8 or ASCII inputs, you may pass a `ReadOnlySpan<byte>` argument.
+Trailing content in the string is ignored.  You may pass an optional `out long characters_consumed` parameter
+`FastDoubleParser.ParseDouble(l, out long characters_consumed)` if you wich to check how many characters were processed. Some users may want to fail when the number of characters consumed does not match the string length.
+
+
+For UTF-8 or ASCII inputs, you may pass a `ReadOnlySpan<byte>` argument. You can also pass
+an optional `out long characters_consumed` parameter to track the number of characters consumed
+by the number pattern.
 
 # Testing
 
-The set of unit tests in /TestcsFastFloat project combines unit tests from many libraries.  It includes tests used by the Go Team.  
+The set of unit tests in /TestcsFastFloat project combines unit tests from many libraries.  It includes tests used by the Go Team.
 Additionnal info on Nigel Tao's work can be found [here](https://nigeltao.github.io/blog/2020/eisel-lemire.html#testing).
 
 # Credit

--- a/TestcsFastFloat/Basic/TestDoubleParser.cs
+++ b/TestcsFastFloat/Basic/TestDoubleParser.cs
@@ -40,7 +40,7 @@ namespace TestcsFastFloat.Tests.Basic
     {
       fixed (char* p = input)
       {
-        Assert.Equal(res, FastDoubleParser.HandleInvalidInput(p, p + input.Length));
+        Assert.Equal(res, FastDoubleParser.HandleInvalidInput(p, p + input.Length, out long _));
       }
     }
 

--- a/TestcsFastFloat/Basic/TestFloatParser.cs
+++ b/TestcsFastFloat/Basic/TestFloatParser.cs
@@ -25,7 +25,7 @@ namespace TestcsFastFloat.Tests.Basic
     {
       fixed (char* p = input)
       {
-        Assert.Equal(res, FastDoubleParser.HandleInvalidInput(p, p + input.Length));
+        Assert.Equal(res, FastDoubleParser.HandleInvalidInput(p, p + input.Length, out long _));
       }
     }
 
@@ -44,7 +44,7 @@ namespace TestcsFastFloat.Tests.Basic
     {
       fixed (char* p = input)
       {
-        Assert.Equal(res, FastFloatParser.HandleInvalidInput(p, p + input.Length)); ;
+        Assert.Equal(res, FastFloatParser.HandleInvalidInput(p, p + input.Length, out long _)); ;
       }
     }
 
@@ -190,7 +190,7 @@ namespace TestcsFastFloat.Tests.Basic
         fixed (char* p = kv.Value)
         {
           char* pend = p + kv.Value.Length;
-          var res = FastDoubleParser.ParseNumber(p, pend);
+          var res = FastDoubleParser.ParseNumber(p, pend, out long _);
 
           sb.AppendLine($"Resultat : {res}");
           sb.AppendLine();

--- a/csFastFloat/FastDoubleParser.cs
+++ b/csFastFloat/FastDoubleParser.cs
@@ -35,8 +35,8 @@ namespace csFastFloat
       word = negative ? word | ((ulong)(1) << DoubleBinaryConstants.sign_index) : word;
 
       return BitConverter.Int64BitsToDouble((long)word);
-    }    
-    
+    }
+
     public  static double FastPath(ParsedNumberString pns)
     {
       double value = (double)pns.mantissa;
@@ -65,6 +65,18 @@ namespace csFastFloat
       }
     }
 
+    public static unsafe double ParseDouble(string s, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+    {
+      if (s == null)
+        ThrowArgumentNull();
+        static void ThrowArgumentNull() => throw new ArgumentNullException(nameof(s));
+
+      fixed (char* pStart = s)
+      {
+        return ParseNumber(pStart, pStart + (uint)s.Length, out characters_consumed, expectedFormat, decimal_separator);
+      }
+    }
+
 
     public static unsafe double ParseDouble(ReadOnlySpan<char> s, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
@@ -74,12 +86,19 @@ namespace csFastFloat
       }
     }
 
- 
-    unsafe static public double ParseDouble(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
-      => ParseNumber(first, last, expectedFormat, decimal_separator);
+    public static unsafe double ParseDouble(ReadOnlySpan<char> s, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+    {
+      fixed (char* pStart = s)
+      {
+        return ParseNumber(pStart, pStart + (uint)s.Length, out characters_consumed, expectedFormat, decimal_separator);
+      }
+    }
 
- 
-    unsafe static internal double ParseNumber(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+    unsafe static public double ParseDouble(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+      => ParseNumber(first, last, out long _, expectedFormat, decimal_separator);
+
+
+    unsafe static internal double ParseNumber(char* first, char* last, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
       while ((first != last) && Utils.is_space((byte)(*first)))
       {
@@ -92,8 +111,9 @@ namespace csFastFloat
       ParsedNumberString pns = ParsedNumberString.ParseNumberString(first, last, expectedFormat);
       if (!pns.valid)
       {
-        return HandleInvalidInput(first, last);
+        return HandleInvalidInput(first, last, out characters_consumed);
       }
+      characters_consumed = pns.characters_consumed;
 
       // Next is Clinger's fast path.
       if (DoubleBinaryConstants.min_exponent_fast_path <= pns.exponent && pns.exponent <= DoubleBinaryConstants.max_exponent_fast_path && pns.mantissa <= DoubleBinaryConstants.max_mantissa_fast_path && !pns.too_many_digits)
@@ -114,8 +134,8 @@ namespace csFastFloat
       if (am.power2 < 0) { am = ParseLongMantissa(first, last, decimal_separator); }
       return ToFloat(pns.negative, am);
     }
-   
-    unsafe static internal Double ParseNumber (byte* first, byte* last, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
+
+    unsafe static internal Double ParseNumber (byte* first, byte* last, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
     {
       while ((first != last) && Utils.is_space(*first))
       {
@@ -128,8 +148,9 @@ namespace csFastFloat
       ParsedNumberString pns = ParsedNumberString.ParseNumberString(first, last, expectedFormat);
       if (!pns.valid)
       {
-        return HandleInvalidInput(first, last);
+        return HandleInvalidInput(first, last, out characters_consumed);
       }
+      characters_consumed = pns.characters_consumed;
 
       // Next is Clinger's fast path.
       if (DoubleBinaryConstants.min_exponent_fast_path <= pns.exponent && pns.exponent <= DoubleBinaryConstants.max_exponent_fast_path && pns.mantissa <= DoubleBinaryConstants.max_mantissa_fast_path && !pns.too_many_digits)
@@ -155,7 +176,14 @@ namespace csFastFloat
     {
       fixed(byte* pStart = s)
       {
-        return ParseNumber(pStart, pStart + s.Length, expectedFormat, decimal_separator);
+        return ParseNumber(pStart, pStart + s.Length, out long _, expectedFormat, decimal_separator);
+      }
+    }
+    public static unsafe double ParseDouble(ReadOnlySpan<byte> s, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
+    {
+      fixed(byte* pStart = s)
+      {
+        return ParseNumber(pStart, pStart + s.Length, out characters_consumed, expectedFormat, decimal_separator);
       }
     }
 
@@ -420,40 +448,52 @@ namespace csFastFloat
     }
 
 
-    unsafe static internal double HandleInvalidInput(char* first, char* last)
+    unsafe static internal double HandleInvalidInput(char* first, char* last, out long characters_consumed)
     {
       if (last - first >= 3)
       {
         if (Utils.strncasecmp(first, "nan", 3))
         {
+          characters_consumed = 3;
           return DoubleBinaryConstants.NaN;
         }
         if (Utils.strncasecmp(first, "inf", 3))
         {
           if ((last - first >= 8) && Utils.strncasecmp(first, "infinity", 8))
+          {
+            characters_consumed = 8;
             return DoubleBinaryConstants.PositiveInfinity;
+          }
+          characters_consumed = 3;
           return DoubleBinaryConstants.PositiveInfinity;
         }
         if (last - first >= 4)
         {
           if (Utils.strncasecmp(first, "+nan", 4) || Utils.strncasecmp(first, "-nan", 4))
           {
+            characters_consumed = 4;
             return DoubleBinaryConstants.NaN;
           }
           if (Utils.strncasecmp(first, "+inf", 4) ||
-              Utils.strncasecmp(first, "-inf", 4) ||
-              ((last - first >= 8) && Utils.strncasecmp(first + 1, "infinity", 8)))
+              Utils.strncasecmp(first, "-inf", 4))
           {
+            if((last - first >= 9) && Utils.strncasecmp(first + 1, "infinity", 8))
+            {
+              characters_consumed = 9;
+            } else {
+              characters_consumed = 4;
+            }
             return (first[0] == '-') ? DoubleBinaryConstants.NegativeInfinity : DoubleBinaryConstants.PositiveInfinity;
           }
         }
       }
       ThrowArgumentException();
+      characters_consumed = 0;
       return 0d;
     }
 
 
-    unsafe static internal double HandleInvalidInput(byte* first, byte* last)
+    unsafe static internal double HandleInvalidInput(byte* first, byte* last, out long characters_consumed)
     {
       // C# does not (yet) allow literal ASCII strings (it uses UTF-16), so
       // we need to use byte arrays.
@@ -476,36 +516,48 @@ namespace csFastFloat
       {
         if (Utils.strncasecmp(first, nan_string, 3))
         {
+          characters_consumed = 3;
           return DoubleBinaryConstants.NaN;
         }
         if (Utils.strncasecmp(first, inf_string, 3))
         {
           if ((last - first >= 8) && Utils.strncasecmp(first, infinity_string, 8))
+          {
+            characters_consumed = 8;
             return DoubleBinaryConstants.PositiveInfinity;
+          }
+          characters_consumed = 3;
           return DoubleBinaryConstants.PositiveInfinity;
         }
         if (last - first >= 4)
         {
           if (Utils.strncasecmp(first, pnan_string, 4) || Utils.strncasecmp(first, mnan_string, 4))
           {
+            characters_consumed = 4;
             return DoubleBinaryConstants.NaN;
           }
           if (Utils.strncasecmp(first, pinf_string, 4) ||
-              Utils.strncasecmp(first, minf_string, 4) ||
-              ((last - first >= 8) && Utils.strncasecmp(first + 1, infinity_string, 8)))
+              Utils.strncasecmp(first, minf_string, 4))
           {
+            if((last - first >= 9) && Utils.strncasecmp(first + 1, infinity_string, 8))
+            {
+              characters_consumed = 9;
+            } else {
+              characters_consumed = 4;
+            }
             return (first[0] == '-') ? DoubleBinaryConstants.NegativeInfinity : DoubleBinaryConstants.PositiveInfinity;
           }
         }
       }
       ThrowArgumentException();
+      characters_consumed = 0;
       return 0d;
     }
 
-   
 
 
-   
+
+
     // This should always succeed since it follows a call to parse_number_string
     // This function could be optimized. In particular, we could stop after 19 digits
     // and try to bail out. Furthermore, we should be able to recover the computed

--- a/csFastFloat/FastFloatParser.cs
+++ b/csFastFloat/FastFloatParser.cs
@@ -64,6 +64,18 @@ namespace csFastFloat
       }
     }
 
+    public static unsafe float ParseFloat(string s, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+    {
+      if (s == null)
+        ThrowArgumentNull();
+        static void ThrowArgumentNull() => throw new ArgumentNullException(nameof(s));
+
+      fixed (char* pStart = s)
+      {
+        return ParseNumber(pStart, pStart + (uint)s.Length, out characters_consumed, expectedFormat, decimal_separator);
+      }
+    }
+
     public static unsafe float ParseFloat(ReadOnlySpan<char> s, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
       fixed (char* pStart = s)
@@ -71,13 +83,18 @@ namespace csFastFloat
         return ParseFloat(pStart, pStart + (uint)s.Length, expectedFormat, decimal_separator);
       }
     }
-
-
+    public static unsafe float ParseFloat(ReadOnlySpan<char> s, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+    {
+      fixed (char* pStart = s)
+      {
+        return ParseNumber(pStart, pStart + (uint)s.Length, out characters_consumed, expectedFormat, decimal_separator);
+      }
+    }
     unsafe static public float ParseFloat(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
-      => ParseNumber(first, last, expectedFormat, decimal_separator);
+      => ParseNumber(first, last, out long _, expectedFormat, decimal_separator);
 
 
-    unsafe static internal float ParseNumber(char* first, char* last, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
+    unsafe static internal float ParseNumber(char* first, char* last, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, char decimal_separator = '.')
     {
       while ((first != last) && Utils.is_space((byte)(*first)))
       {
@@ -90,8 +107,9 @@ namespace csFastFloat
       ParsedNumberString pns = ParseNumberString(first, last, expectedFormat);
       if (!pns.valid)
       {
-        return HandleInvalidInput(first, last);
+        return HandleInvalidInput(first, last, out characters_consumed);
       }
+      characters_consumed = pns.characters_consumed;
 
       // Next is Clinger's fast path.
       if (FloatBinaryConstants.min_exponent_fast_path <= pns.exponent && pns.exponent <= FloatBinaryConstants.max_exponent_fast_path && pns.mantissa <= FloatBinaryConstants.max_mantissa_fast_path && !pns.too_many_digits)
@@ -114,7 +132,7 @@ namespace csFastFloat
     }
 
 
-    unsafe static internal float ParseNumber(byte* first, byte* last, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
+    unsafe static internal float ParseNumber(byte* first, byte* last, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
     {
       while ((first != last) && Utils.is_space(*first))
       {
@@ -127,8 +145,9 @@ namespace csFastFloat
       ParsedNumberString pns = ParseNumberString(first, last, expectedFormat);
       if (!pns.valid)
       {
-        return HandleInvalidInput(first, last);
+        return HandleInvalidInput(first, last, out characters_consumed);
       }
+      characters_consumed = pns.characters_consumed;
 
       // Next is Clinger's fast path.
       if (FloatBinaryConstants.min_exponent_fast_path <= pns.exponent && pns.exponent <= FloatBinaryConstants.max_exponent_fast_path && pns.mantissa <= FloatBinaryConstants.max_mantissa_fast_path && !pns.too_many_digits)
@@ -153,10 +172,16 @@ namespace csFastFloat
     {
       fixed(byte* pStart = s)
       {
-        return ParseNumber(pStart, pStart + s.Length, expectedFormat, decimal_separator);
+        return ParseNumber(pStart, pStart + s.Length, out long _, expectedFormat, decimal_separator);
       }
     }
-
+    public static unsafe float ParseFloat(ReadOnlySpan<byte> s, out long characters_consumed, chars_format expectedFormat = chars_format.is_general, byte decimal_separator = (byte)'.')
+    {
+      fixed(byte* pStart = s)
+      {
+        return ParseNumber(pStart, pStart + s.Length, out characters_consumed, expectedFormat, decimal_separator);
+      }
+    }
     /// <summary>
     ///
     /// </summary>
@@ -427,39 +452,51 @@ namespace csFastFloat
 
 
 
-    unsafe static internal float HandleInvalidInput(char* first, char* last)
+    unsafe static internal float HandleInvalidInput(char* first, char* last, out long characters_consumed)
     {
       if (last - first >= 3)
       {
         if (Utils.strncasecmp(first, "nan", 3))
         {
+          characters_consumed = 3;
           return FloatBinaryConstants.NaN;
         }
         if (Utils.strncasecmp(first, "inf", 3))
         {
           if ((last - first >= 8) && Utils.strncasecmp(first, "infinity", 8))
+          {
+            characters_consumed = 8;
             return FloatBinaryConstants.PositiveInfinity;
+          }
+          characters_consumed = 3;
           return FloatBinaryConstants.PositiveInfinity;
         }
         if (last - first >= 4)
         {
           if (Utils.strncasecmp(first, "+nan", 4) || Utils.strncasecmp(first, "-nan", 4))
           {
+            characters_consumed = 4;
             return FloatBinaryConstants.NaN;
           }
           if (Utils.strncasecmp(first, "+inf", 4) ||
-              Utils.strncasecmp(first, "-inf", 4) ||
-              ((last - first >= 8) && Utils.strncasecmp(first + 1, "infinity", 8)))
+              Utils.strncasecmp(first, "-inf", 4))
           {
+            if((last - first >= 9) && Utils.strncasecmp(first + 1, "infinity", 8))
+            {
+              characters_consumed = 9;
+            } else {
+              characters_consumed = 4;
+            }
             return (first[0] == '-') ? FloatBinaryConstants.NegativeInfinity : FloatBinaryConstants.PositiveInfinity;
           }
         }
       }
       ThrowArgumentException();
+      characters_consumed = 0;
       return 0f;
     }
 
-    unsafe static internal float HandleInvalidInput(byte* first, byte* last)
+    unsafe static internal float HandleInvalidInput(byte* first, byte* last, out long characters_consumed)
     {
       // C# does not (yet) allow literal ASCII strings (it uses UTF-16), so
       // we need to use byte arrays.
@@ -482,29 +519,41 @@ namespace csFastFloat
       {
         if (Utils.strncasecmp(first, nan_string, 3))
         {
+          characters_consumed = 3;
           return FloatBinaryConstants.NaN;
         }
         if (Utils.strncasecmp(first, inf_string, 3))
         {
           if ((last - first >= 8) && Utils.strncasecmp(first, infinity_string, 8))
+          {
+            characters_consumed = 8;
             return FloatBinaryConstants.PositiveInfinity;
+          }
+          characters_consumed = 3;
           return FloatBinaryConstants.PositiveInfinity;
         }
         if (last - first >= 4)
         {
           if (Utils.strncasecmp(first, pnan_string, 4) || Utils.strncasecmp(first, mnan_string, 4))
           {
+            characters_consumed = 4;
             return FloatBinaryConstants.NaN;
           }
           if (Utils.strncasecmp(first, pinf_string, 4) ||
-              Utils.strncasecmp(first, minf_string, 4) ||
-              ((last - first >= 8) && Utils.strncasecmp(first + 1, infinity_string, 8)))
+              Utils.strncasecmp(first, minf_string, 4))
           {
+            if((last - first >= 9) && Utils.strncasecmp(first + 1, infinity_string, 8))
+            {
+              characters_consumed = 9;
+            } else {
+              characters_consumed = 4;
+            }
             return (first[0] == '-') ? FloatBinaryConstants.NegativeInfinity : FloatBinaryConstants.PositiveInfinity;
           }
         }
       }
       ThrowArgumentException();
+      characters_consumed = 0;
       return 0f;
     }
 
@@ -517,6 +566,7 @@ namespace csFastFloat
 
       answer.valid = false;
       answer.too_many_digits = false;
+      char* pstart = p;
       answer.negative = (*p == '-');
       if ((*p == '-') || (*p == '+'))
       {
@@ -606,8 +656,8 @@ namespace csFastFloat
         // If it scientific and not fixed, we have to bail out.
         if ((expectedFormat.HasFlag(chars_format.is_scientific)) && !(expectedFormat.HasFlag(chars_format.is_fixed))) { return answer; }
       }
-      //answer.lastmatch = p;
       answer.valid = true;
+      answer.characters_consumed = p - pstart;
 
       // If we frequently had to deal with long strings of digits,
       // we could extend our code by using a 128-bit integer instead
@@ -668,6 +718,7 @@ namespace csFastFloat
 
       answer.valid = false;
       answer.too_many_digits = false;
+      byte* pstart = p;
       answer.negative = (*p == '-');
       if ((*p == '-') || (*p == '+'))
       {
@@ -764,8 +815,8 @@ namespace csFastFloat
         // If it scientific and not fixed, we have to bail out.
         if ((expectedFormat.HasFlag(chars_format.is_scientific)) && !(expectedFormat.HasFlag(chars_format.is_fixed))) { return answer; }
       }
-      //answer.lastmatch = p;
       answer.valid = true;
+      answer.characters_consumed = p - pstart;
 
       // If we frequently had to deal with long strings of digits,
       // we could extend our code by using a 128-bit integer instead

--- a/csFastFloat/Structures/ParsedNumberString.cs
+++ b/csFastFloat/Structures/ParsedNumberString.cs
@@ -7,6 +7,8 @@ namespace csFastFloat.Structures
   {
     internal long exponent;
     internal ulong mantissa;
+  
+    internal long characters_consumed;
     internal bool negative;
     internal bool valid;
     internal bool too_many_digits;
@@ -18,6 +20,7 @@ namespace csFastFloat.Structures
 
       answer.valid = false;
       answer.too_many_digits = false;
+      char* pstart = p;
       answer.negative = (*p == '-');
       if ((*p == '-') || (*p == '+'))
       {
@@ -107,8 +110,8 @@ namespace csFastFloat.Structures
         // If it scientific and not fixed, we have to bail out.
         if ((expectedFormat.HasFlag(chars_format.is_scientific)) && !(expectedFormat.HasFlag(chars_format.is_fixed))) { return answer; }
       }
-      //answer.lastmatch = p;
       answer.valid = true;
+      answer.characters_consumed = p - pstart;
 
       // If we frequently had to deal with long strings of digits,
       // we could extend our code by using a 128-bit integer instead
@@ -169,6 +172,7 @@ namespace csFastFloat.Structures
 
       answer.valid = false;
       answer.too_many_digits = false;
+      byte* pstart = p;
       answer.negative = (*p == '-');
       if ((*p == '-') || (*p == '+'))
       {
@@ -199,9 +203,9 @@ namespace csFastFloat.Structures
       if ((p != pend) && (*p == decimal_separator))
       {
         ++p;
-        if ((p + 8 <= pend) && Utils.is_made_of_eight_digits_fast(p)) 
+        if ((p + 8 <= pend) && Utils.is_made_of_eight_digits_fast(p))
         {
-          i = i * 100000000 + Utils.parse_eight_digits_unrolled(p); 
+          i = i * 100000000 + Utils.parse_eight_digits_unrolled(p);
           p += 8;
           if ((p + 8 <= pend) && Utils.is_made_of_eight_digits_fast(p)) {
             i = i * 100000000 + Utils.parse_eight_digits_unrolled(p);
@@ -265,8 +269,8 @@ namespace csFastFloat.Structures
         // If it scientific and not fixed, we have to bail out.
         if ((expectedFormat.HasFlag(chars_format.is_scientific)) && !(expectedFormat.HasFlag(chars_format.is_fixed))) { return answer; }
       }
-      //answer.lastmatch = p;
       answer.valid = true;
+      answer.characters_consumed = p - pstart;
 
       // If we frequently had to deal with long strings of digits,
       // we could extend our code by using a 128-bit integer instead


### PR DESCRIPTION
Should be self-explanatory. 

This is better than failing when there are trailing characters as suggested in https://github.com/CarlVerret/csFastFloat/issues/47 because some users, given the string `"  3.14, joe  "` really want it to parse to 3.14 and not to get a format exception. In this instance, the code here would report that 5 characters were consumed. You could then choose to fail.

I have not added the tests. Contributions invited. I did find what I think is a small bug ("ginfinity" might be parsed as 'infinity').

- [ ] Add tests

Fixes https://github.com/CarlVerret/csFastFloat/issues/61
Fixes https://github.com/CarlVerret/csFastFloat/issues/47